### PR TITLE
Added clustering as a model type in cli check

### DIFF
--- a/igel/cli.py
+++ b/igel/cli.py
@@ -233,7 +233,7 @@ class CLI(object):
                           f"type can be whether regression, classification or clustering \n")
                     self._print_models_overview()
                     return
-                if model_type not in ('regression', 'classification'):
+                if model_type not in ('regression', 'classification', 'clustering'):
                     raise Exception(f"{model_type} is not supported! \n"
                                     f"model_type need to be regression, classification or clustering")
 


### PR DESCRIPTION
Hello 👋  I was testing out this awesome tool and looking at the model definitions but clustering is missing from the model check:

```bash
$ igel models -type clustering -name Birch                                                                                                               
Traceback (most recent call last):
  File "/usr/local/bin/igel", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.8/site-packages/igel/cli.py", line 315, in main
    CLI()
  File "/usr/local/lib/python3.8/site-packages/igel/cli.py", line 113, in __init__
    getattr(self, self.cmd.command)()
  File "/usr/local/lib/python3.8/site-packages/igel/cli.py", line 237, in models
    raise Exception(f"{model_type} is not supported! \n"
Exception: clustering is not supported!
model_type need to be regression, classification or clustering
```

This patch just updates the check to work with clustering
```bash
jonathanhinds@Jonathans-MBP ~/D/ml-learn> igel models -type clustering -name Birch                                                                                                                   (base)
model type: clustering
model name: Birch
sklearn model class: Birch
------------------------------------------------------------
You can click the link below to know more about the optional arguments that you can use with your chosen model (Birch).
You can provide these optional arguments in the yaml file if you want to use them
link: https://scikit-learn.org/stable/modules/generated/sklearn.cluster.Birch.html#sklearn.cluster.Birch
```