### PR TITLE
Provide copy button for code blocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ coverage: ## check code coverage quickly with the default Python
 docs: ## generate Sphinx HTML documentation, including API docs
 	rm -f docs/igel.rst
 	rm -f docs/modules.rst
-	pip install -r dev_requirements.txt
+	pip install -r requirements_dev.txt
 	sphinx-apidoc -o docs/ igel
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,11 +17,11 @@
 # relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.
 #
+import igel
 import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))
 
-import igel
 
 # -- General configuration ---------------------------------------------
 
@@ -33,7 +33,8 @@ html_logo = '../assets/logo.jpg'
 # needs_sphinx = '1.0'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.autosectionlabel'] # , 'sphinx_copybutton'
+extensions = ['sphinx_copybutton', 'sphinx.ext.autodoc',
+              'sphinx.ext.viewcode', 'sphinx.ext.autosectionlabel']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -93,7 +94,7 @@ html_theme = 'classic'
 #
 html_theme_options = {
     'canonical_url': '',
-    'analytics_id': 'UA-XXXXXXX-1',  #  Provided by Google in your dashboard
+    'analytics_id': 'UA-XXXXXXX-1',  # Provided by Google in your dashboard
     'logo_only': False,
     'display_version': True,
     'prev_next_buttons_location': 'bottom',
@@ -174,6 +175,3 @@ texinfo_documents = [
      'One line description of project.',
      'Miscellaneous'),
 ]
-
-
-

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,5 +13,5 @@ pytest-runner==5.2
 pandas==1.1.1
 PyYAML==5.3.1
 scikit-learn==0.23.2
-sphinx-copybutton==0.3.0
+sphinx-copybutton==0.3.1
 sphinx_glpi_theme==0.3


### PR DESCRIPTION
This closes #23

Example from the generated Sphinx HTML documentation after running `make docs`

![image](https://user-images.githubusercontent.com/3610244/119677133-bf336b80-be3e-11eb-8f71-86ffba4f3462.png)
