### PR TITLE
Updated Commands to setup fork for local development

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -69,7 +69,7 @@ Ready to contribute? Here's how to set up `igel` for local development.
     $ cd igel/
     $ poetry shell
     $ poetry update
-    $ python install
+    $ poetry install
 
 4. Create a branch for local development::
 


### PR DESCRIPTION
The command "python install" was changed to "poetry install" which seems to be the right command to install project igel for local development