### PR TITLE
Bug fix in __main.py__ and addition of important commands 

### DIFF
--- a/igel/__init__.py
+++ b/igel/__init__.py
@@ -10,7 +10,7 @@ from .igel import Igel, metrics_dict, models_dict
 try:
     __version__ = version(__name__)
 except PackageNotFoundError:
-    __version__ = "0.4.0"
+    __version__ = "0.5.0"
 
 
 __author__ = "Nidhal Baccouri"

--- a/igel/__main__.py
+++ b/igel/__main__.py
@@ -90,12 +90,16 @@ def predict(data_path: str) -> None:
     """
     Igel(cmd="predict", data_path=data_path)
 
+if len(sys.argv) == 8:
+    narg=3
+else:
+    narg=1
 
 @cli.command(context_settings=CONTEXT_SETTINGS)
 @click.option(
     "--data_paths",
     "-DP",
-    nargs=3,
+    nargs=narg,
     required=True,
     help="Path to your datasets as string separated by space",
 )
@@ -105,16 +109,20 @@ def predict(data_path: str) -> None:
     required=True,
     help="Path to your igel configuration file (yaml or json file)",
 )
-def experiment(data_paths: tuple , yaml_path: str) -> None:
+def experiment(data_paths , yaml_path: str) -> None:
     """
     train, evaluate and use pre-trained model for predictions in one command
     """
-    train_data_path, eval_data_path, pred_data_path = data_paths[0], data_paths[1], data_paths[2]
+    if isinstance(data_paths, str):
+        train_data_path, eval_data_path, pred_data_path = data_paths.strip().split(" ")
+    else:
+        train_data_path, eval_data_path, pred_data_path = data_paths[0], data_paths[1], data_paths[2]
+
     Igel(cmd="fit", data_path=train_data_path, yaml_path=yaml_path)
     Igel(cmd="evaluate", data_path=eval_data_path)
     Igel(cmd="predict", data_path=pred_data_path)
-
-
+    
+    
 @cli.command(context_settings=CONTEXT_SETTINGS)
 @click.option(
     "--model_results_dir",


### PR DESCRIPTION
_Bug_

It should be noted that when an optional argument is required to hold multiple values as in the case of ```-DP/--data_paths``` it should be taken care with the help of ```nargs``` feature. For example on executing the following we met this issue.
```
$ igel experiment -DP 3.csv 3.csv e.csv -yml igel.yaml
Usage: igel experiment [OPTIONS]
Try 'igel experiment --help' for help.

Error: Got unexpected extra arguments (3.csv e.csv)
```
Note ```3.csv```, ```e.csv```, ```igel.yaml``` files are present in the same working directory.

Hence this method of separating the paths for the required files will not work as mentioned below:
```
def experiment(data_paths: str, yaml_path: str) -> None:
    .
    .

    train_data_path, eval_data_path, pred_data_path = data_paths.strip().split(" ")
```

The above bug can be solved by introducing ```nargs=3``` and it will return data_paths as a tuple which is resolved in this PR.

_Addition of important commands_

Since igel is a package and as per the documentation the following missing commands have been added.
```
  info        get info & metadata about igel
  help        get help about how to use igel
  version     get the version of igel installed on your machine
```

_Shortcut for help option in every command_

This enhances the igel and increases the easiness to fetch the help of any command. To fetch the help list earlier we have to specify the complete name as ```--help``` but now user can specify a short flag ```-h``` to fetch the help command quickly.


In case of any query or improvement kindly mention, I will be happy to do it.