### PR TITLE
Fix email address in code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at jean.bisutti@gmail.com. All
+reported by contacting the project team at nidhalbacc@gmail.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
In general i think this code of conduct does not do any harm and is a good thing. But think that the way @loic5 have been spamming these PRs across GitHub repositories is not maybe the most elegant way to introduce them.

This fixes the email address that is referred in the document to something i found in the readme of the project.