### PR TITLE
Added docs for using the API for a served model

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -414,7 +414,7 @@ and `uvicorn <https://www.uvicorn.org/>`_ to run it under the hood.
 Using the API with the served model
 ###################################
 
-This example was done using a pre-trained model (created by running igel init --target sick -type classification) and the Indian Diabetes dataset downloaded from Kaggle (here). The headers of the columns in the original CSV are ‘preg’, ‘plas’, ‘pres’, ‘skin’, ‘test’, ‘mass’, ‘pedi’ and ‘age’.
+This example was done using a pre-trained model (created by running igel init --target sick -type classification) and the Indian Diabetes dataset under examples/data. The headers of the columns in the original CSV are ‘preg’, ‘plas’, ‘pres’, ‘skin’, ‘test’, ‘mass’, ‘pedi’ and ‘age’.
 
 **CURL:**
 
@@ -433,7 +433,7 @@ This example was done using a pre-trained model (created by running igel init --
 
     $ curl -X POST localhost:8080/predict --header "Content-Type:application/json" -d '{"preg": [1, 6, 10], "plas":[192, 52, 180], "pres": [40, 30, 50], "skin": [25, 35, 12], "test": [0, 1, 1], "mass": [456, 123, 155], "pedi": [0.442, 0.22, 0.19], "age": [50, 40, 29]}'
 
-    Outputs: ``{"prediction":[[1.0],[0.0],[0.0]]}``
+    Outputs: {"prediction":[[1.0],[0.0],[0.0]]}
 
 **Caveats/Limitations:**
 
@@ -455,7 +455,7 @@ This example was done using a pre-trained model (created by running igel init --
   # you can post other types of files compatible with what Igel data reading allows
   client.post("my_batch_file_for_predicting.csv")
 
-  Outputs: ``<Response 200>: {"prediction":[[1.0],[0.0],[0.0]]}``
+  Outputs: <Response 200>: {"prediction":[[1.0],[0.0],[0.0]]}
 
 ----------------------------------------------------------------------------------------------------------
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -417,28 +417,35 @@ Using the API with the served model
 This example was done using a pre-trained model (created by running igel init --target sick -type classification) and the Indian Diabetes dataset downloaded from Kaggle (here). The headers of the columns in the original CSV are ‘preg’, ‘plas’, ‘pres’, ‘skin’, ‘test’, ‘mass’, ‘pedi’ and ‘age’.
 
 **CURL:**
-Post with single entry for each predictor
+
+
+- Post with single entry for each predictor
 
 .. code-block:: console
+
     $ curl -X POST localhost:8080/predict --header "Content-Type:application/json" -d '{"preg": 1, "plas": 180, "pres": 50, "skin": 12, "test": 1, "mass": 456, "pedi": 0.442, "age": 50}'
 
-Outputs: `{"prediction":[[0.0]]}`
+    Outputs: {"prediction":[[0.0]]}
 
-Post with multiple options for each predictor
+- Post with multiple options for each predictor
+
 .. code-block:: console
+
     $ curl -X POST localhost:8080/predict --header "Content-Type:application/json" -d '{"preg": [1, 6, 10], "plas":[192, 52, 180], "pres": [40, 30, 50], "skin": [25, 35, 12], "test": [0, 1, 1], "mass": [456, 123, 155], "pedi": [0.442, 0.22, 0.19], "age": [50, 40, 29]}'
 
-Outputs: `{"prediction":[[1.0],[0.0],[0.0]]}`
+    Outputs: ``{"prediction":[[1.0],[0.0],[0.0]]}``
 
-Caveats/Limitations:
-* each predictor used to train the model must make an appearance in your data (i.e. don’t leave any columns out)
-* each list must have the same number of elements or you’ll get an Internal Server Error 
-* as an extension of this, you cannot mix single elements and lists (i.e. {“plas”: 0, “pres”: [1, 2]} isn't allowed)
-* the predict function takes a data path arg and reads in the data for you but with serving and calling your served model, you’ll have to parse the data into JSON yourself however, the python client provided in `examples/python_client.py` will do that for you
+**Caveats/Limitations:**
 
-Example usage of the Python Client:
+- each predictor used to train the model must make an appearance in your data (i.e. don’t leave any columns out)
+- each list must have the same number of elements or you’ll get an Internal Server Error 
+- as an extension of this, you cannot mix single elements and lists (i.e. {“plas”: 0, “pres”: [1, 2]} isn't allowed)
+- the predict function takes a data path arg and reads in the data for you but with serving and calling your served model, you’ll have to parse the data into JSON yourself however, the python client provided in `examples/python_client.py` will do that for you
+
+**Example usage of the Python Client:**
 
 .. code-block:: python
+
   from python_client import IgelClient
 
   # the client allows additional args with defaults: 
@@ -448,8 +455,7 @@ Example usage of the Python Client:
   # you can post other types of files compatible with what Igel data reading allows
   client.post("my_batch_file_for_predicting.csv")
 
-Outputs: `<Response 200>: {"prediction":[[1.0],[0.0],[0.0]]}`
-
+  Outputs: ``<Response 200>: {"prediction":[[1.0],[0.0],[0.0]]}``
 
 ----------------------------------------------------------------------------------------------------------
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -411,20 +411,45 @@ and `uvicorn <https://www.uvicorn.org/>`_ to run it under the hood.
 
 ----------------------------------------------------------------------------------------------------------
 
+Using the API with the served model
+###################################
 
-Use igel from python (instead of terminal)
-###########################################
+This example was done using a pre-trained model (created by running igel init --target sick -type classification) and the Indian Diabetes dataset downloaded from Kaggle (here). The headers of the columns in the original CSV are ‘preg’, ‘plas’, ‘pres’, ‘skin’, ‘test’, ‘mass’, ‘pedi’ and ‘age’.
 
-- Alternatively, you can also write code if you want to:
+**CURL:**
+Post with single entry for each predictor
 
-..  code-block:: python
+.. code-block:: console
+    $ curl -X POST localhost:8080/predict --header "Content-Type:application/json" -d '{"preg": 1, "plas": 180, "pres": 50, "skin": 12, "test": 1, "mass": 456, "pedi": 0.442, "age": 50}'
 
-    from igel import Igel
+Outputs: `{"prediction":[[0.0]]}`
 
-    Igel(cmd="fit", data_path="path_to_your_dataset", yaml_path="path_to_your_yaml_file")
-    """
-    check the examples folder for more
-    """
+Post with multiple options for each predictor
+.. code-block:: console
+    $ curl -X POST localhost:8080/predict --header "Content-Type:application/json" -d '{"preg": [1, 6, 10], "plas":[192, 52, 180], "pres": [40, 30, 50], "skin": [25, 35, 12], "test": [0, 1, 1], "mass": [456, 123, 155], "pedi": [0.442, 0.22, 0.19], "age": [50, 40, 29]}'
+
+Outputs: `{"prediction":[[1.0],[0.0],[0.0]]}`
+
+Caveats/Limitations:
+* each predictor used to train the model must make an appearance in your data (i.e. don’t leave any columns out)
+* each list must have the same number of elements or you’ll get an Internal Server Error 
+* as an extension of this, you cannot mix single elements and lists (i.e. {“plas”: 0, “pres”: [1, 2]} isn't allowed)
+* the predict function takes a data path arg and reads in the data for you but with serving and calling your served model, you’ll have to parse the data into JSON yourself however, the python client provided in `examples/python_client.py` will do that for you
+
+Example usage of the Python Client:
+
+.. code-block:: python
+  from python_client import IgelClient
+
+  # the client allows additional args with defaults: 
+  # scheme="http", endpoint="predict", missing_values="mean"
+  client = IgelClient(host='localhost', port=8080)
+
+  # you can post other types of files compatible with what Igel data reading allows
+  client.post("my_batch_file_for_predicting.csv")
+
+Outputs: `<Response 200>: {"prediction":[[1.0],[0.0],[0.0]]}`
+
 
 ----------------------------------------------------------------------------------------------------------
 

--- a/examples/python_client.py
+++ b/examples/python_client.py
@@ -1,6 +1,8 @@
-import requests
 import json
+import requests
+
 from igel.preprocessing import handle_missing_values, read_data_to_df
+
 
 class IgelClient:
     """ A mini client example that reads some data file and formats

--- a/examples/python_client.py
+++ b/examples/python_client.py
@@ -1,0 +1,28 @@
+import requests
+import json
+from igel.preprocessing import handle_missing_values, read_data_to_df
+
+class IgelClient:
+    """ A mini client example that reads some data file and formats
+        it for the post call to predict
+    """
+    def __init__(self, host, port, scheme="http", endpoint="predict", missing_values='mean'):
+        self.url = f"{scheme}://{host}:{port}/{endpoint}"
+        self.missing_values = missing_values
+
+    def process_data(self, data_file):
+        """ Use the inbuilt handle_missing_values since missing values can't be sent in 
+            valid JSON without raising an error
+        """
+        data_df = handle_missing_values(read_data_to_df(data_file), strategy=self.missing_values)
+
+        # make a dict of {header: column values}, JSONify, return        
+        data_dict = data_df.to_dict(orient='list', into=dict)
+        jsonified = json.dumps(data_dict)
+        return jsonified
+
+    def post(self, data_file):
+        output_json = self.process_data(data_file)
+        res = requests.post(self.url, data=output_json)
+        print(f"{res}: {res.text}")
+        return res


### PR DESCRIPTION
What I did:
* Added documentation on how to call the served model using the API -> both Curl and using a Python client
* Wrote a mini Python client that will also process data files into JSON content that can be posted
* Removed a duplicate section from the docs about using the igel commands directly in Python


Closes #73 