### PR TITLE
docs: Add detailed comment explaining flag creation 'ugly hack' in Ma…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,19 @@ SHELL := /usr/bin/env bash
 IMAGE := igel
 VERSION := latest
 
+# -----------------------------------------------------------------------------
+# The following section sets command flags for various tools (poetry, pip, safety, etc.)
+# based on whether "strict" mode is enabled. This is done by setting each flag variable
+# to either "-" (non-strict) or "" (strict).
+#
+# Why this is done this way:
+# Make does not support creating variables in a loop or dynamically generating variable
+# names in a portable way. While GNU Make has some advanced features, this Makefile aims
+# to be as portable and readable as possible. Therefore, each flag variable is set
+# individually, even though this results in repetitive code.
+#
+# If you know a more concise, portable way to achieve this, contributions are welcome!
+# -----------------------------------------------------------------------------
 #! An ugly hack to create individual flags
 ifeq ($(STRICT), 1)
 	POETRY_COMMAND_FLAG =


### PR DESCRIPTION
This PR adds a detailed comment above the section in the Makefile responsible for creating individual command flags for various tools (such as poetry, pip, safety, etc.). The comment explains why this repetitive approach is necessary due to Makefile limitations, and invites contributors to suggest more concise, portable solutions if available.

fix https://github.com/nidhaloff/igel/issues/125: Refactor or document the "ugly hack" for flag creation in Makefile.

