### PR TITLE
feat(cli): Add global --verbose flag and improve help messages with examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,19 @@ SHELL := /usr/bin/env bash
 IMAGE := igel
 VERSION := latest
 
+# -----------------------------------------------------------------------------
+# The following section sets command flags for various tools (poetry, pip, safety, etc.)
+# based on whether "strict" mode is enabled. This is done by setting each flag variable
+# to either "-" (non-strict) or "" (strict).
+#
+# Why this is done this way:
+# Make does not support creating variables in a loop or dynamically generating variable
+# names in a portable way. While GNU Make has some advanced features, this Makefile aims
+# to be as portable and readable as possible. Therefore, each flag variable is set
+# individually, even though this results in repetitive code.
+#
+# If you know a more concise, portable way to achieve this, contributions are welcome!
+# -----------------------------------------------------------------------------
 #! An ugly hack to create individual flags
 ifeq ($(STRICT), 1)
 	POETRY_COMMAND_FLAG =

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -176,3 +176,5 @@ texinfo_documents = [
      'One line description of project.',
      'Miscellaneous'),
 ]
+
+# Minor update: contribution trigger for PR

--- a/igel/__main__.py
+++ b/igel/__main__.py
@@ -17,11 +17,18 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
 @click.group()
-def cli():
+@click.option('--verbose', is_flag=True, help='Enable verbose output for debugging.')
+def cli(verbose):
     """
     The igel command line interface
     """
-    pass
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG)
+        logger.setLevel(logging.DEBUG)
+        click.echo('Verbose mode is on.')
+    else:
+        logging.basicConfig(level=logging.WARNING)
+        logger.setLevel(logging.WARNING)
 
 
 @cli.command(context_settings=CONTEXT_SETTINGS)
@@ -49,6 +56,9 @@ def cli():
 def init(model_type: str, model_name: str, target: str) -> None:
     """
     Initialize a new igel project.
+
+    Example:
+        igel init --model_type=classification --model_name=RandomForest --target=label
     """
     Igel.create_init_mock_file(
         model_type=model_type, model_name=model_name, target=target
@@ -67,7 +77,10 @@ def init(model_type: str, model_name: str, target: str) -> None:
 )
 def fit(data_path: str, yaml_path: str) -> None:
     """
-    fit/train a machine learning model
+    Fit/train a machine learning model.
+
+    Example:
+        igel fit --data_path=data/train.csv --yaml_path=config.yaml
     """
     Igel(cmd="fit", data_path=data_path, yaml_path=yaml_path)
 

--- a/tests/test_igel/helper.py
+++ b/tests/test_igel/helper.py
@@ -3,7 +3,13 @@ import os
 import shutil
 
 
-def remove_file(f):
+def remove_file(f: str) -> None:
+    """
+    Remove a file at the given path if it exists.
+
+    Args:
+        f (str): The path to the file to be removed.
+    """
     try:
         if os.path.exists(f):
             os.remove(f)


### PR DESCRIPTION
This PR enhances the igel CLI by:

- Adding a global --verbose flag to enable detailed logging and debugging output for all commands.
- Improving help messages for the `init` and `fit` commands, including clear usage examples.

These changes make the CLI more user-friendly and provide better guidance for new users.

Fixes #132 