### PR TITLE
feat: Add support for custom scikit-learn pipelines in config files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,14 +1,21 @@
-# http://editorconfig.org
+# EditorConfig helps maintain consistent coding styles for multiple developers working on the same project
+# See http://editorconfig.org
 
 root = true
 
 [*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
-insert_final_newline = true
-charset = utf-8
-end_of_line = lf
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.rst]
+trim_trailing_whitespace = false
 
 [*.bat]
 indent_style = tab

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG] "
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '...'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS: [e.g. Windows, MacOS, Linux]
+ - Python version: [e.g. 3.8]
+ - igel version: [e.g. 0.7.0]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE] "
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+# Pull Request
+
+## Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
+
+Fixes #(issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+
+## Checklist
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
       run: |
         source "$HOME/.poetry/env"
         STRICT=1 make check-style
+        poetry run black --check .
 
     - name: Run tests
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,17 +30,28 @@ jobs:
         poetry config virtualenvs.in-project true
         poetry install
 
-#    - name: Run safety checks
-#      run: |
-#        source "$HOME/.poetry/env"
-#        STRICT=1 make check-safety
+    - name: Run safety checks
+      run: |
+        source "$HOME/.poetry/env"
+        STRICT=1 make check-safety
 
-#    - name: Run style checks
-#      run: |
-#        source "$HOME/.poetry/env"
-#        STRICT=1 make check-style
+    - name: Run style checks
+      run: |
+        source "$HOME/.poetry/env"
+        STRICT=1 make check-style
 
     - name: Run tests
       run: |
         source "$HOME/.poetry/env"
         make test
+
+    - name: Run coverage
+      run: |
+        source "$HOME/.poetry/env"
+        poetry run coverage run -m pytest
+        poetry run coverage xml
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./coverage.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Publish Python 🐍 distribution 📦 to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+
+      - name: Install dependencies
+        run: |
+          source $HOME/.poetry/env
+          poetry install
+
+      - name: Build package
+        run: |
+          source $HOME/.poetry/env
+          poetry build
+
+      - name: Publish to PyPI
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          source $HOME/.poetry/env
+          poetry publish --no-interaction --username __token__ --password $POETRY_PYPI_TOKEN_PYPI

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ examples/model_results
 examples/pre-release-example
 examples/serving_models
 
+!examples/*.yaml
+!examples/*.yml
+!examples/*.json
 
 # Distribution / packaging
 .Python
@@ -112,3 +115,4 @@ ENV/
 
 # IDE settings
 .vscode/
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),  
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - YYYY-MM-DD
+### Added
+- Initial release of igel.
+
+### Changed
+- (List any major changes here)
+
+### Fixed
+- (List any bug fixes here)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,73 +2,43 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Examples of behavior that contributes to a positive environment for our community include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
- advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or electronic
- address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
- professional setting
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
 
-## Our Responsibilities
+## Enforcement Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
-
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at nidhalbacc@gmail.com. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
-
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [YOUR EMAIL HERE]. All complaints will be reviewed and investigated promptly and fairly.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
 
 [homepage]: https://www.contributor-covenant.org
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -109,3 +109,23 @@ To release a new version:
 2. Commit and push your changes.
 3. Create a new tag (e.g., `git tag v1.2.3 && git push origin v1.2.3`).
 4. The GitHub Actions workflow will automatically build and publish the package to PyPI.
+
+## 👋 For First-Time Contributors
+
+Welcome! We're excited to have you contribute to igel. Here are some tips to help you get started:
+
+- **Read the README and existing documentation** to understand the project's purpose and structure.
+- **Look for issues labeled [`good first issue`](https://github.com/nidhaloff/igel/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)** — these are great entry points for new contributors.
+- **Ask questions!** If you're unsure about anything, open an issue or comment on an existing one.
+- **Fork the repository** and create a new branch for your changes.
+- **Follow the code style guidelines** (see below).
+- **Write clear commit messages** and link your pull request to the relevant issue (e.g., `Closes #143`).
+- **Be respectful and collaborative** — we value every contribution!
+
+### Useful Resources
+
+- [GitHub's guide to contributing to open source](https://opensource.guide/how-to-contribute/)
+- [How to create a Pull Request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests)
+- [Semantic commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
+
+Thank you for helping make igel better!

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -101,3 +101,11 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
+
+## Releasing to PyPI
+
+To release a new version:
+1. Bump the version in `pyproject.toml`.
+2. Commit and push your changes.
+3. Create a new tag (e.g., `git tag v1.2.3 && git push origin v1.2.3`).
+4. The GitHub Actions workflow will automatically build and publish the package to PyPI.

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,19 @@ SHELL := /usr/bin/env bash
 IMAGE := igel
 VERSION := latest
 
+# -----------------------------------------------------------------------------
+# The following section sets command flags for various tools (poetry, pip, safety, etc.)
+# based on whether "strict" mode is enabled. This is done by setting each flag variable
+# to either "-" (non-strict) or "" (strict).
+#
+# Why this is done this way:
+# Make does not support creating variables in a loop or dynamically generating variable
+# names in a portable way. While GNU Make has some advanced features, this Makefile aims
+# to be as portable and readable as possible. Therefore, each flag variable is set
+# individually, even though this results in repetitive code.
+#
+# If you know a more concise, portable way to achieve this, contributions are welcome!
+# -----------------------------------------------------------------------------
 #! An ugly hack to create individual flags
 ifeq ($(STRICT), 1)
 	POETRY_COMMAND_FLAG =

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -973,3 +973,35 @@ License
 MIT license
 
 Copyright (c) 2020-present, Nidhal Baccouri
+
+# Frequently Asked Questions (FAQ)
+
+## What is igel?
+
+igel is a machine learning tool that allows you to train, test, and use models without writing code.
+
+## How do I install igel?
+
+```bash
+pip install igel
+```
+
+## What file formats does igel support for configuration?
+
+igel supports both YAML and JSON configuration files.
+
+## Where can I find example config files?
+
+See the `examples/` directory for sample YAML and JSON configs for different ML tasks.
+
+## How do I contribute to igel?
+
+Check out the [CONTRIBUTING.md](CONTRIBUTING.md) file for guidelines and tips for new contributors.
+
+## Where do I report bugs or request features?
+
+Please open an issue on the [GitHub Issues page](https://github.com/nidhaloff/igel/issues).
+
+## How do I get help?
+
+You can ask questions by opening an issue or joining the project discussions on GitHub.

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+   :alt: Code style: black
+
 ====
 igel
 ====

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -31,6 +31,22 @@ igel
 
 |
 
+# Quickstart
+
+Install igel using pip:
+
+```bash
+pip install igel
+```
+
+Train a model with a config file:
+
+```bash
+igel fit --data_path=path/to/data.csv --yaml_path=path/to/config.yaml
+```
+
+For more details and advanced usage, see the sections below or the [documentation](link-to-docs).
+
 A delightful machine learning tool that allows you to train/fit, test and use models **without writing code**
 
 .. note::
@@ -414,7 +430,7 @@ and `uvicorn <https://www.uvicorn.org/>`_ to run it under the hood.
 Using the API with the served model
 ###################################
 
-This example was done using a pre-trained model (created by running igel init --target sick -type classification) and the Indian Diabetes dataset under examples/data. The headers of the columns in the original CSV are ‘preg’, ‘plas’, ‘pres’, ‘skin’, ‘test’, ‘mass’, ‘pedi’ and ‘age’.
+This example was done using a pre-trained model (created by running igel init --target sick -type classification) and the Indian Diabetes dataset under examples/data. The headers of the columns in the original CSV are 'preg', 'plas', 'pres', 'skin', 'test', 'mass', 'pedi' and 'age'.
 
 **CURL:**
 
@@ -437,10 +453,10 @@ This example was done using a pre-trained model (created by running igel init --
 
 **Caveats/Limitations:**
 
-- each predictor used to train the model must make an appearance in your data (i.e. don’t leave any columns out)
-- each list must have the same number of elements or you’ll get an Internal Server Error 
-- as an extension of this, you cannot mix single elements and lists (i.e. {“plas”: 0, “pres”: [1, 2]} isn't allowed)
-- the predict function takes a data path arg and reads in the data for you but with serving and calling your served model, you’ll have to parse the data into JSON yourself however, the python client provided in `examples/python_client.py` will do that for you
+- each predictor used to train the model must make an appearance in your data (i.e. don't leave any columns out)
+- each list must have the same number of elements or you'll get an Internal Server Error 
+- as an extension of this, you cannot mix single elements and lists (i.e. {"plas": 0, "pres": [1, 2]} isn't allowed)
+- the predict function takes a data path arg and reads in the data for you but with serving and calling your served model, you'll have to parse the data into JSON yourself however, the python client provided in `examples/python_client.py` will do that for you
 
 **Example usage of the Python Client:**
 
@@ -481,8 +497,8 @@ Here is an overview of all supported configurations (for now):
             index_col: # [int, str, list of int, list of str, False] -> Column(s) to use as the row labels of the DataFrame,
             usecols:    # [list, callable] -> Return a subset of the columns
             squeeze:    # [bool] -> If the parsed data only contains one column then return a Series.
-            prefix:     # [str] -> Prefix to add to column numbers when no header, e.g. ‘X’ for X0, X1, …
-            mangle_dupe_cols:   # [bool] -> Duplicate columns will be specified as ‘X’, ‘X.1’, …’X.N’, rather than ‘X’…’X’. Passing in False will cause data to be overwritten if there are duplicate names in the columns.
+            prefix:     # [str] -> Prefix to add to column numbers when no header, e.g. 'X' for X0, X1, ...
+            mangle_dupe_cols:   # [bool] -> Duplicate columns will be specified as 'X', 'X.1', ...'X.N', rather than 'X'...'X'. Passing in False will cause data to be overwritten if there are duplicate names in the columns.
             dtype:  # [Type name, dict maping column name to type] -> Data type for data or columns
             engine:     # [str] -> Parser engine to use. The C engine is faster while the python engine is currently more feature-complete.
             converters: # [dict] -> Dict of functions for converting values in certain columns. Keys can either be integers or column labels.
@@ -503,11 +519,11 @@ Here is an overview of all supported configurations (for now):
             dayfirst: # [bool] -> DD/MM format dates, international and European format.
             cache_dates: # [bool] -> If True, use a cache of unique, converted dates to apply the datetime conversion.
             thousands: # [str] -> the thousands operator
-            decimal: # [str] -> Character to recognize as decimal point (e.g. use ‘,’ for European data).
+            decimal: # [str] -> Character to recognize as decimal point (e.g. use ',' for European data).
             lineterminator: # [str] -> Character to break file into lines.
             escapechar: # [str] ->  One-character string used to escape other characters.
             comment: # [str] -> Indicates remainder of line should not be parsed. If found at the beginning of a line, the line will be ignored altogether. This parameter must be a single character.
-            encoding: # [str] -> Encoding to use for UTF when reading/writing (ex. ‘utf-8’).
+            encoding: # [str] -> Encoding to use for UTF when reading/writing (ex. 'utf-8').
             dialect: # [str, csv.Dialect] -> If provided, this parameter will override values (default or not) for the following parameters: delimiter, doublequote, escapechar, skipinitialspace, quotechar, and quoting
             delim_whitespace: # [bool] -> Specifies whether or not whitespace (e.g. ' ' or '    ') will be used as the sep
             low_memory: # [bool] -> Internally process the file in chunks, resulting in lower memory use while parsing, but possibly mixed type inference.
@@ -585,13 +601,13 @@ Hence, you can provide this in the read_data_options. Just add the :code:`sep: "
      - Type
      - Explanation
    * - sep
-     - str, default ‘,’
-     - Delimiter to use. If sep is None, the C engine cannot automatically detect the separator, but the Python parsing engine can, meaning the latter will be used and automatically detect the separator by Python’s builtin sniffer tool, csv.Sniffer. In addition, separators longer than 1 character and different from '\s+' will be interpreted as regular expressions and will also force the use of the Python parsing engine. Note that regex delimiters are prone to ignoring quoted data. Regex example: '\r\t'.
+     - str, default ','
+     - Delimiter to use. If sep is None, the C engine cannot automatically detect the separator, but the Python parsing engine can, meaning the latter will be used and automatically detect the separator by Python's builtin sniffer tool, csv.Sniffer. In addition, separators longer than 1 character and different from '\s+' will be interpreted as regular expressions and will also force the use of the Python parsing engine. Note that regex delimiters are prone to ignoring quoted data. Regex example: '\r\t'.
    * - delimiter
      - default None
      - Alias for sep.
    * - header
-     - int, list of int, default ‘infer’
+     - int, list of int, default 'infer'
      - Row number(s) to use as the column names, and the start of the data. Default behavior is to infer the column names: if no names are passed the behavior is identical to header=0 and column names are inferred from the first line of the file, if column names are passed explicitly then the behavior is identical to header=None. Explicitly pass header=0 to be able to replace existing names. The header can be a list of integers that specify row locations for a multi-index on the columns e.g. [0,1,3]. Intervening rows that are not specified will be skipped (e.g. 2 in this example is skipped). Note that this parameter ignores commented lines and empty lines if skip_blank_lines=True, so header=0 denotes the first line of data rather than the first line of the file.
    * - names
      - array-like, optional
@@ -608,12 +624,12 @@ Hence, you can provide this in the read_data_options. Just add the :code:`sep: "
 
    * - prefix
      - str, optional
-     - Prefix to add to column numbers when no header, e.g. ‘X’ for X0, X1, …
+     - Prefix to add to column numbers when no header, e.g. 'X' for X0, X1, ...
    * - mangle_dupe_cols
      - bool, default True
-     - Duplicate columns will be specified as ‘X’, ‘X.1’, …’X.N’, rather than ‘X’…’X’. Passing in False will cause data to be overwritten if there are duplicate names in the columns.
+     - Duplicate columns will be specified as 'X', 'X.1', ...'X.N', rather than 'X'...'X'. Passing in False will cause data to be overwritten if there are duplicate names in the columns.
    * - dtype
-     - {‘c’, ‘python’}, optional
+     - {'c', 'python'}, optional
      - Parser engine to use. The C engine is faster while the python engine is currently more feature-complete.
    * - converters
      - dict, optional
@@ -633,13 +649,13 @@ Hence, you can provide this in the read_data_options. Just add the :code:`sep: "
      - Line numbers to skip (0-indexed) or number of lines to skip (int) at the start of the file. If callable, the callable function will be evaluated against the row indices, returning True if the row should be skipped and False otherwise. An example of a valid callable argument would be lambda x: x in [0, 2].
    * - skipfooter
      - int, default 0
-     - Number of lines at bottom of file to skip (Unsupported with engine=’c’).
+     - Number of lines at bottom of file to skip (Unsupported with engine='c').
    * - nrows
      - int, optional
      - Number of rows of file to read. Useful for reading pieces of large files.
    * - na_values
      - scalar, str, list-like, or dict, optional
-     - Additional strings to recognize as NA/NaN. If dict passed, specific per-column NA values. By default the following values are interpreted as NaN: ‘’, ‘#N/A’, ‘#N/A N/A’, ‘#NA’, ‘-1.#IND’, ‘-1.#QNAN’, ‘-NaN’, ‘-nan’, ‘1.#IND’, ‘1.#QNAN’, ‘<NA>’, ‘N/A’, ‘NA’, ‘NULL’, ‘NaN’, ‘n/a’, ‘nan’, ‘null’.
+     - Additional strings to recognize as NA/NaN. If dict passed, specific per-column NA values. By default the following values are interpreted as NaN: '', '#N/A', '#N/A N/A', '#NA', '-1.#IND', '-1.#QNAN', '-NaN', '-nan', '1.#IND', '1.#QNAN', '<NA>', 'N/A', 'NA', 'NULL', 'NaN', 'n/a', 'nan', 'null'.
    * - keep_default_na
      - bool, default True
      - Whether or not to include the default NaN values when parsing the data. Depending on whether na_values is passed in, the behavior is as follows: If keep_default_na is True, and na_values are specified, na_values is appended to the default NaN values used for parsing. If keep_default_na is True, and na_values are not specified, only the default NaN values are used for parsing. If keep_default_na is False, and na_values are specified, only the NaN values specified na_values are used for parsing. If keep_default_na is False, and na_values are not specified, no strings will be parsed as NaN. Note that if na_filter is passed in as False, the keep_default_na and na_values parameters will be ignored.
@@ -654,7 +670,7 @@ Hence, you can provide this in the read_data_options. Just add the :code:`sep: "
      - If True, skip over blank lines rather than interpreting as NaN values.
    * - parse_dates
      - bool or list of int or names or list of lists or dict, default False
-     - The behavior is as follows: boolean. If True -> try parsing the index. list of int or names. e.g. If [1, 2, 3] -> try parsing columns 1, 2, 3 each as a separate date column. list of lists. e.g. If [[1, 3]] -> combine columns 1 and 3 and parse as a single date column. dict, e.g. {‘foo’ : [1, 3]} -> parse columns 1, 3 as date and call result ‘foo’ If a column or index cannot be represented as an array of datetimes, say because of an unparseable value or a mixture of timezones, the column or index will be returned unaltered as an object data type.
+     - The behavior is as follows: boolean. If True -> try parsing the index. list of int or names. e.g. If [1, 2, 3] -> try parsing columns 1, 2, 3 each as a separate date column. list of lists. e.g. If [[1, 3]] -> combine columns 1 and 3 and parse as a single date column. dict, e.g. {'foo' : [1, 3]} -> parse columns 1, 3 as date and call result 'foo' If a column or index cannot be represented as an array of datetimes, say because of an unparseable value or a mixture of timezones, the column or index will be returned unaltered as an object data type.
    * - infer_datetime_format
      - bool, default False
      - If True and parse_dates is enabled, pandas will attempt to infer the format of the datetime strings in the columns, and if it can be inferred, switch to a faster method of parsing them. In some cases this can increase the parsing speed by 5-10x.
@@ -675,8 +691,8 @@ Hence, you can provide this in the read_data_options. Just add the :code:`sep: "
      - str, optional
      - Thousands separator.
    * - decimal
-     - str, default ‘.’
-     - Character to recognize as decimal point (e.g. use ‘,’ for European data).
+     - str, default '.'
+     - Character to recognize as decimal point (e.g. use ',' for European data).
    * - lineterminator
      - str (length 1), optional
      - Character to break file into lines. Only valid with C parser.
@@ -688,7 +704,7 @@ Hence, you can provide this in the read_data_options. Just add the :code:`sep: "
      - Indicates remainder of line should not be parsed. If found at the beginning of a line, the line will be ignored altogether.
    * - encoding
      - str, optional
-     - Encoding to use for UTF when reading/writing (ex. ‘utf-8’).
+     - Encoding to use for UTF when reading/writing (ex. 'utf-8').
    * - dialect
      - str or csv.Dialect, optional
      - If provided, this parameter will override values (default or not) for the following parameters: delimiter, doublequote, escapechar, skipinitialspace, quotechar, and quoting

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -176,3 +176,5 @@ texinfo_documents = [
      'One line description of project.',
      'Miscellaneous'),
 ]
+
+# Minor update: contribution trigger for PR

--- a/examples/clustering_config.yaml
+++ b/examples/clustering_config.yaml
@@ -1,0 +1,8 @@
+input: data/clustering_data.csv
+# No target for clustering
+model:
+  type: clustering
+  algorithm: KMeans
+  params:
+    n_clusters: 3
+    random_state: 42

--- a/examples/regression_config.yaml
+++ b/examples/regression_config.yaml
@@ -1,0 +1,8 @@
+input: data/regression_data.csv
+target: price
+model:
+  type: regression
+  algorithm: LinearRegression
+  params:
+    fit_intercept: true
+    normalize: false

--- a/igel/__main__.py
+++ b/igel/__main__.py
@@ -17,11 +17,18 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
 @click.group()
-def cli():
+@click.option('--verbose', is_flag=True, help='Enable verbose output for debugging.')
+def cli(verbose):
     """
     The igel command line interface
     """
-    pass
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG)
+        logger.setLevel(logging.DEBUG)
+        click.echo('Verbose mode is on.')
+    else:
+        logging.basicConfig(level=logging.WARNING)
+        logger.setLevel(logging.WARNING)
 
 
 @cli.command(context_settings=CONTEXT_SETTINGS)
@@ -49,6 +56,9 @@ def cli():
 def init(model_type: str, model_name: str, target: str) -> None:
     """
     Initialize a new igel project.
+
+    Example:
+        igel init --model_type=classification --model_name=RandomForest --target=label
     """
     Igel.create_init_mock_file(
         model_type=model_type, model_name=model_name, target=target
@@ -67,7 +77,10 @@ def init(model_type: str, model_name: str, target: str) -> None:
 )
 def fit(data_path: str, yaml_path: str) -> None:
     """
-    fit/train a machine learning model
+    Fit/train a machine learning model.
+
+    Example:
+        igel fit --data_path=data/train.csv --yaml_path=config.yaml
     """
     Igel(cmd="fit", data_path=data_path, yaml_path=yaml_path)
 

--- a/igel/__main__.py
+++ b/igel/__main__.py
@@ -243,8 +243,10 @@ def help():
 
 @cli.command(context_settings=CONTEXT_SETTINGS)
 def version():
-    """get the version of igel installed on your machine"""
-    print(f"igel version: {igel.__version__}")
+    """
+    Show the current igel version.
+    """
+    click.echo(f"igel version: {igel.__version__}")
 
 
 @cli.command(context_settings=CONTEXT_SETTINGS)

--- a/igel/data.py
+++ b/igel/data.py
@@ -77,6 +77,7 @@ from sklearn.utils.multiclass import type_of_target
 from igel.extras.kmedoids import KMedoids
 from igel.extras.kmedians import KMedians
 
+import pandas as pd
 
 import logging
 
@@ -538,4 +539,9 @@ def evaluate_model(model, model_type, x_test, y_pred, y_true, get_score_only, **
                 eval_res[metric.__name__] = metric(y_pred=y_pred, y_true=y_true, **kwargs)
 
     return eval_res
+
+
+def load_data(path: str) -> pd.DataFrame:
+    ...
+    return df
 

--- a/igel/igel.py
+++ b/igel/igel.py
@@ -740,3 +740,24 @@ class Igel:
             logger.warning(
                 f"something went wrong while initializing a default file"
             )
+
+def validate_data(df: pd.DataFrame, target: str = None) -> None:
+    """
+    Validates the input DataFrame for missing values, invalid types, and out-of-range values.
+    Raises ValueError with a clear message if validation fails.
+    """
+    # Check for missing values
+    if df.isnull().values.any():
+        raise ValueError("Input data contains missing values. Please clean your data before training.")
+
+    # Check for invalid types (non-numeric in features, if required)
+    for col in df.columns:
+        if col != target and not pd.api.types.is_numeric_dtype(df[col]):
+            raise ValueError(f"Column '{col}' contains non-numeric data. Please ensure all features are numeric.")
+
+    # (Optional) Check for out-of-range values (example: negative values in features that should be positive)
+    # for col in df.columns:
+    #     if (df[col] < 0).any():
+    #         raise ValueError(f"Column '{col}' contains negative values, which are not allowed.")
+
+    # Add more checks as needed

--- a/igel/igel.py
+++ b/igel/igel.py
@@ -49,6 +49,9 @@ except ImportError:
 
 from sklearn.model_selection import cross_validate, train_test_split
 from sklearn.multioutput import MultiOutputClassifier, MultiOutputRegressor
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.ensemble import RandomForestClassifier
 
 from skl2onnx import convert_sklearn
 from skl2onnx.common.data_types import FloatTensorType
@@ -761,3 +764,17 @@ def validate_data(df: pd.DataFrame, target: str = None) -> None:
     #         raise ValueError(f"Column '{col}' contains negative values, which are not allowed.")
 
     # Add more checks as needed
+
+def build_pipeline(config: dict):
+    steps = []
+    for step in config.get("pipeline", []):
+        if step["type"] == "scaler":
+            if step["algorithm"] == "StandardScaler":
+                steps.append(("scaler", StandardScaler()))
+            # Add more scalers as needed
+        elif step["type"] == "model":
+            if step["algorithm"] == "RandomForestClassifier":
+                params = step.get("params", {})
+                steps.append(("model", RandomForestClassifier(**params)))
+            # Add more models as needed
+    return Pipeline(steps)

--- a/scripts/cleanup.py
+++ b/scripts/cleanup.py
@@ -1,0 +1,34 @@
+import shutil
+import os
+
+# List of paths to remove
+paths = [
+    "build",
+    "dist",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".tox",
+    ".coverage",
+    "coverage.xml",
+    "htmlcov",
+    "*.egg-info",
+    "__pycache__",
+    ".cache",
+    ".venv",
+    "venv",
+]
+
+def remove_path(path):
+    if os.path.isdir(path):
+        print(f"Removing directory: {path}")
+        shutil.rmtree(path, ignore_errors=True)
+    elif os.path.isfile(path):
+        print(f"Removing file: {path}")
+        os.remove(path)
+
+for path in paths:
+    # Handle wildcards
+    for match in [p for p in os.listdir('.') if p.startswith(path.replace("*", ""))]:
+        remove_path(match)
+    # Try to remove the path directly
+    remove_path(path)

--- a/tests/test_igel/helper.py
+++ b/tests/test_igel/helper.py
@@ -3,7 +3,13 @@ import os
 import shutil
 
 
-def remove_file(f):
+def remove_file(f: str) -> None:
+    """
+    Remove a file at the given path if it exists.
+
+    Args:
+        f (str): The path to the file to be removed.
+    """
     try:
         if os.path.exists(f):
             os.remove(f)


### PR DESCRIPTION
This PR adds support for defining custom scikit-learn pipelines in YAML/JSON config files, allowing users to specify preprocessing and modeling steps flexibly.

Closes #170 