### PR TITLE
Add --log-level command

### DIFF
--- a/igel/__main__.py
+++ b/igel/__main__.py
@@ -15,12 +15,20 @@ from igel.utils import print_models_overview, show_model_info, tableize
 logger = logging.getLogger(__name__)
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
-
-@click.group()
-def cli():
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.option(
+    "--log-level",
+    default="INFO",
+    show_default=True,
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], case_sensitive=False),
+    help="Set the logging level.",
+)
+def cli(log_level):
     """
     The igel command line interface
     """
+    logging.basicConfig(level=getattr(logging, log_level.upper()))
+    logger.setLevel(getattr(logging, log_level.upper()))
     pass
 
 
@@ -231,7 +239,7 @@ def help():
 @cli.command(context_settings=CONTEXT_SETTINGS)
 def version():
     """get the version of igel installed on your machine"""
-    print(f"igel version: {igel.__version__}")
+    logger.info(f"igel version: {igel.__version__}")
 
 
 @cli.command(context_settings=CONTEXT_SETTINGS)


### PR DESCRIPTION
Related to #183 

Feature: Allow logging level to be specified from the CLI
A global --log-level option has been added to the main igel command, allowing users to define the level of detail of the log messages they want to see when running any CLI command.

Main Changes
The --log-level option has been added to the main group of commands using Click.
The supported levels are: DEBUG, INFO, WARNING, ERROR, and CRITICAL.
The logging level is set at the start of execution, affecting all commands and log messages.
The CLI help has been updated to reflect the new option.

Example of use:

igel --log-level info version