### PR TITLE
Improve Makefile documentation for command flag handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,16 @@ SHELL := /usr/bin/env bash
 IMAGE := igel
 VERSION := latest
 
-#! An ugly hack to create individual flags
+#-----------------------------------------------------------------------
+#Conditional configuration for tool command flags
+#
+#When STRICT=1, all tools run in strict mode(no dash prefix)
+#When STRICT is unset, dash-prefixed flags(-) are used to disable strict checks
+#This approach ensures comaptibility across Poetry, Pip, Safety, Bandit, and other tools.
+#
+#Note: Make does not support dynamic variable creation in a portable way,
+#so flags are defined explicitly below clarity
+#------------------------------------------------------------------------
 ifeq ($(STRICT), 1)
 	POETRY_COMMAND_FLAG =
 	PIP_COMMAND_FLAG =


### PR DESCRIPTION
Description
I’ve cleaned up and rewritten the comments in the Makefile section that defines individual command flags.
The goal was to make it easier for others to understand what this part of the file does and why the flags are set individually.
The functionality hasn’t changed — only the explanation and wording. I also replaced the “ugly hack” phrasing with a more descriptive note that explains the reasoning behind it.


Notes 
No behavior change 
Just documentation to make file beginner friendly